### PR TITLE
Updated JS Permission Manager Event Handler

### DIFF
--- a/javascript/permission-dialog.js
+++ b/javascript/permission-dialog.js
@@ -24,20 +24,20 @@
 				$('select[name=permission]').append('<option></option>').append(options);
 			}
 		});
-
-		// we search for any .permissionManager, and get the info
-		$('.permissionManager').livequery(function () {
-			var nodeInfo = $(this).data('object');
-			$(this).click (function () {
-				initialiseDialog(nodeInfo);
-			})
-		})
+		
+		$(".permission-manager").live("click", function() {
+			initialiseDialog({
+				id:   $(this).data("id"),
+				type: $(this).data("type")
+			});
+			return false;
+		});
 		
 		function initialiseDialog(nodeInfo) {
 			var params = {
 				SecurityID: securityId, 
-				nodeID: nodeInfo.ID, 
-				nodeType: nodeInfo.Type
+				nodeID: nodeInfo.id,
+				nodeType: nodeInfo.type
 			}
 			
 			var addPermDialogOpts = {


### PR DESCRIPTION
The permission popup event handler didn't work for links since it wasn't stopping event propagation. Also updated the event handler to follow HTML naming conventions and broken the object data up into two separate parameters to avoid JSON parsing.
